### PR TITLE
Allow logs from thread mode

### DIFF
--- a/example/examples/read.rs
+++ b/example/examples/read.rs
@@ -9,12 +9,16 @@ use lm3s6965::{interrupt, Interrupt};
 use panic_never as _;
 
 funnel!(NVIC_PRIO_BITS = 3, {
+    0: 32,
     1: 32,
     2: 64,
 });
 
 #[entry]
 fn main() -> ! {
+
+    info!("Idle thread");
+
     let mut itm = if let Some(p) = cortex_m::Peripherals::take() {
         unsafe {
             let mut nvic = p.NVIC;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -45,7 +45,7 @@ fn main(input: Input) -> parse::Result<TokenStream> {
 
     let mut map = BTreeMap::new();
     for kv in &input.map {
-        let k = lit2ux(&kv.priority, Some(1..=upper))?;
+        let k = lit2ux(&kv.priority, Some(0..=upper))?;
         let v: usize = lit2ux(&kv.size, Some(1..=usize::max_value()))?;
 
         if map.contains_key(&k) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl Logger {
 
             if icsr == 0 {
                 // thread mode
-                None
+                __funnel_logger(0)
             } else if icsr < 16 {
                 // TODO do something about exceptions -- NMI and HardFault are annoying because they
                 // have exceptional priorities


### PR DESCRIPTION
I understand thread mode shouldn't need the fast logging since it's lowest priority, but I think it is still nice to have for:
- Timing critical startup / initialization (E.g. passive NFC)
- Development
- Allows using same logging API in both idle threat and interrupts.